### PR TITLE
Prevents connection error using Virtual Server

### DIFF
--- a/octoprint_malyan_connection_fix/__init__.py
+++ b/octoprint_malyan_connection_fix/__init__.py
@@ -39,6 +39,12 @@ class MalyanConnectionFixPlugin(octoprint.plugin.OctoPrintPlugin):
 				comm_instance._log("Failed to autodetect serial port, please set it manually.")
 				return None
 
+		# Do not try to handle the Virtual Printer with this plugin
+		# solves Issue 2 https://github.com/OctoPrint/OctoPrint-MalyanConnectionFix/issues/2
+		if port == "VIRTUAL":
+			comm_instance._log("Bypassing Malyan/Monoprice Connection Fix Plugin when using Virtual Printer")
+			return None
+
 		# connect to regular serial port
 		comm_instance._log("Connecting to: %s" % port)
 		comm_instance._log("Using Malyan/Monoprice Connection Fix Plugin to create serial connection")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_malyan_connection_fix"
 plugin_name = "OctoPrint-MalyanConnectionFix"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.0"
+plugin_version = "0.1.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Please see Issue #2 for details
https://github.com/OctoPrint/OctoPrint-MalyanConnectionFix/issues/2

The change itself is very simple: if the port is VIRTUAL then don't try anything, just return None.